### PR TITLE
Added start task to Makefile and package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DEBUG = DEBUG=lorem,lorem:*
 BIN = ./node_modules/.bin
 TESTS = server/test/*.test.js
 MOCHA_OPTS = -b --timeout 10000 --reporter spec
+NODEMON+CONFIG = ./configs/nodemon.json
 
 lint:
 	@echo "Linting..."
@@ -16,8 +17,10 @@ test-coveralls: test-cov
 	@cat ./coverage/lcov.info | $(BIN)/coveralls --verbose
 .PHONY: lint test test-cov test-coveralls
 
+start:
+	@NODE_ENV=production $(DEBUG) $(BIN)/nodemon --config ${NODEMON_CONFIG} .
 start-dev:
-	@NODE_ENV=development $(DEBUG) $(BIN)/nodemon --config ./configs/nodemon.json .
+	@NODE_ENV=development $(DEBUG) $(BIN)/nodemon --config ${NODEMON_CONFIG} .
 start-staging:
-	@NODE_ENV=staging $(DEBUG) $(BIN)/nodemon --config ./configs/nodemon.json .
+	@NODE_ENV=staging $(DEBUG) $(BIN)/nodemon --config ${NODEMON_CONFIG} .
 .PHONY: start-dev start-staging

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "make test",
     "test-cov": "make test-cov",
     "test-coveralls": "make test-coveralls",
+    "start": "make start",
     "start-dev": "make start-dev",
     "start-staging": "make start-staging"
   },


### PR DESCRIPTION
Added missing `start` script to the package.json. now you can type the common command `npm start` to bring up the loopback server