### PR TITLE
editorconfig add max_line_length settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
-max_line_length = 80
+max_line_length = 120
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,6 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
+max_line_length = 80
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
small editorconfig changes to set the max_line_length to the common 80 character length